### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/Notes.bbl
+++ b/Notes.bbl
@@ -38,7 +38,7 @@
 \providecommand \@url [1]{\endgroup\@href {#1}{\urlprefix }}%
 \providecommand \urlprefix  [0]{URL }%
 \providecommand \Eprint [0]{\href }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo  [0]{\@secondoftwo}%
 \providecommand \bibfield  [0]{\@secondoftwo}%

--- a/RamanLLcontinuum.bbl
+++ b/RamanLLcontinuum.bbl
@@ -38,7 +38,7 @@
 \providecommand \@url [1]{\endgroup\@href {#1}{\urlprefix }}%
 \providecommand \urlprefix  [0]{URL }%
 \providecommand \Eprint [0]{\href }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo  [0]{\@secondoftwo}%
 \providecommand \bibfield  [0]{\@secondoftwo}%

--- a/strain_refs.bib
+++ b/strain_refs.bib
@@ -165,7 +165,7 @@
  	author = {{Rammal, R.}},
  	title = {Landau level spectrum of Bloch electrons in a honeycomb lattice},
  	DOI= "10.1051/jphys:019850046080134500",
- 	url= "http://dx.doi.org/10.1051/jphys:019850046080134500",
+ 	url= "https://doi.org/10.1051/jphys:019850046080134500",
  	journal = {J. Phys. France},
  	year = 1985,
  	volume = 46,


### PR DESCRIPTION
Same as https://github.com/qftphys/Scientific-Python-toolbox-for-large-scale-tight-binding-and-electronic-structure-transport-calculati/pull/1, but also including the code that generates new DOIs ;-)